### PR TITLE
Update Evergreen.psd1

### DIFF
--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -33,7 +33,7 @@ Copyright = '(c) 2025 stealthpuppy, EUC Pilots. All rights reserved.'
 Description = 'Create evergreen Windows image builds with the latest versions of applications. Evergreen is a simple PowerShell module that retrieves the latest version numbers and download URLs for various software products directly from the vendor source.'
 
 # Minimum version of the Windows PowerShell engine required by this module
-PowerShellVersion = '3.0'
+PowerShellVersion = '4.0'
 
 # Name of the Windows PowerShell host required by this module
 # PowerShellHostName = ''
@@ -121,7 +121,7 @@ PrivateData = @{
         ReleaseNotes = 'https://eucpilots.com/evergreen-docs/changelog'
 
         # Prerelease string of this module
-        Prerelease = 'beta'
+        # Prerelease = 'beta'
 
         # Flag to indicate whether the module requires explicit user acceptance for install/update/save
         # RequireLicenseAcceptance = $false


### PR DESCRIPTION
Remove beta tag for publishing a new version to production that splits the application functions and manifests from the core module. Changed the minimum required PowerShell version from 3.0 to 4.0 in the module manifest.