### PR TITLE
Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,8 +51,8 @@ body:
       label: Have you reviewed the documentation?
       description: "Please confirm that you've reviewed the following links:"
       options:
-        - label: "Troubleshooting at: https://eucpilots.com/evergreen-docs/troubleshoot/"
-        - label: "Known issues at: https://eucpilots.com/evergreen-docs/issues/"
+        - label: "Troubleshooting at: https://eucpilots.com/evergreen/troubleshoot/"
+        - label: "Known issues at: https://eucpilots.com/evergreen/issues/"
   - type: textarea
     id: verbose
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,8 +4,8 @@ contact_links:
     url: https://github.com/EUCPilots/evergreen-apps/issues
     about: For new apps, see the evergreen-apps repository.
   - name: Review known issues
-    url: https://eucpilots.com/evergreen-docs/issues
+    url: https://eucpilots.com/evergreen/issues
     about: Please ensure you have read the Evergreen known issues list before creating an issue.
   - name: Review troubleshooting
-    url: https://eucpilots.com/evergreen-docs/troubleshoot/
+    url: https://eucpilots.com/evergreen/troubleshoot/
     about: Please ensure you have read the Evergreen troubleshooting article before creating an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -28,4 +28,4 @@ body:
       label: Have you reviewed the documentation?
       description: "Please confirm that you've reviewed the documentation before making this feature request."
       options:
-        - label: "Documentation at: https://eucpilots.com/evergreen-docs/"
+        - label: "Documentation at: https://eucpilots.com/evergreen/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -945,7 +945,7 @@ BREAKING CHANGES
 * Update `VMwareHorizonClient` with additional filtering to select the latest version correctly to address [#161](https://github.com/aaronparker/evergreen/issues/161)
 * Add internal function `Save-File` to download a URL with `Invoke-WebRequest` and return the downloaded file path
 * Update internal application functions for consistent use of `Resolve-SystemNetWebRequest` to address [#174](https://github.com/aaronparker/evergreen/issues/174) - `Get-FoxitReader`, `Get-LogMeInGoToOpener`, `Get-MicrosoftSsms`, `Get-MicrosoftVisualStudio`, `Get-RingCentral`, `Get-Slack`
-* Update references to documentation site `https://eucpilots.com/evergreen-docs` to `https://eucpilots.com/evergreen-docs`
+* Update references to documentation site `https://eucpilots.com/evergreen` to `https://eucpilots.com/evergreen`
 
 ## 2105.383
 
@@ -984,7 +984,7 @@ BREAKING CHANGES
 
 * Changes `FoxitReader` to return MSI installers instead of EXEs. Removes Elex, Portuguese (Portugal), and Turkish language support from this application because the installers returned are out of date.
 * Adds the following languages to `AdobeAcrobatReaderDC`: Swedish, Basque, Catalan, Croatian, Czech, Hungarian, Polish, Romanian, Russian, Slovakian, Slovenian, Turkish, Ukrainian
-* Adds a known issues list to the documentation: [https://eucpilots.com/evergreen-docs/knownissues.html](https://eucpilots.com/evergreen-docs/knownissues.html)
+* Adds a known issues list to the documentation: [https://eucpilots.com/evergreen/knownissues.html](https://eucpilots.com/evergreen/knownissues.html)
 
 ## 2104.348
 
@@ -998,7 +998,7 @@ BREAKING CHANGES
 
 ## 2104.337
 
-* **BREAKING CHANGE**: This version removes the `Get-` function for each application and introduces `Get-EvergreenApp`. See the docs site on how to use the new functions [https://eucpilots.com/evergreen-docs/](https://eucpilots.com/evergreen-docs/)
+* **BREAKING CHANGE**: This version removes the `Get-` function for each application and introduces `Get-EvergreenApp`. See the docs site on how to use the new functions [https://eucpilots.com/evergreen/](https://eucpilots.com/evergreen/)
 * Adds `Get-EvergreenApp`, `Find-EvergreenApp` and `Save-EvergreenApp`
 * Adds file type to SourceForge applications
 * Re-instates `ControlUpAgent` and `ControlUpConsole`
@@ -1049,7 +1049,7 @@ BREAKING CHANGES
 * Updates `Get-MicrosoftWvdRemoteDesktop` to output the `URI` property value in the format `https://query.prod.cms.rt.microsoft.com/cms/api/am/binary/RE4MntQ` instead of the original `fwlink` source URL (e.g. `https://go.microsoft.com/fwlink/?linkid=2068602`)
 * Updates the following functions to use `Invoke-RestMethod` (via `Invoke-RestMethodWrapper`) instead of `Invoke-WebRequest` to simplify code and fix an issue where some functions where returning `Version` as a PSObject instead of System.String ([#109](https://github.com/aaronparker/Evergreen/issues/109))
   * `Get-AtlassianBitbucket`, `Get-Cyberduck`, `Get-FileZilla`, `Get-Fork`, `Get-RingCentral`, `Get-ScooterBeyondCompare`, `Get-SumatraPDFReader`, `Get-VideoLanVlcPlayer`
-* Updates module `ReleaseNotes` location to: [https://eucpilots.com/evergreen-docs/changelog.html](https://eucpilots.com/evergreen-docs/changelog.html)
+* Updates module `ReleaseNotes` location to: [https://eucpilots.com/evergreen/changelog.html](https://eucpilots.com/evergreen/changelog.html)
 
 ## 2101.281
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## VERSION
+
+* `Get-GitHubRepoRelease` - Add logic to remove the Sha256 property when the asset has no digest. This prevents emitting an empty Sha256 field for Windows assets and ensures the output object only contains the digest when present
+* `Get-InstallerType ` - Add more output strings to provide more values to `InstallerType` property. Address [#124](https://github.com/EUCPilots/evergreen-apps/issues/124)
+* Normalise "anycpu" to "any", and "aarch64" to "ARM64" in `Get-Architecture`
+
 ## 2603.2832.0
 
 * Update `Shared/Get-AzulZulu.ps1` - Refine the selection to exclude gzipped downloads when filtering latest releases.

--- a/Evergreen/Evergreen.json
+++ b/Evergreen/Evergreen.json
@@ -78,8 +78,8 @@
     },
     "Uri": {
         "Project": "https://github.com/eucpilots/evergreen-module/",
-        "Docs": "https://eucpilots.com/evergreen-docs/",
-        "Issues": "https://eucpilots.com/evergreen-docs/issues/",
-        "Info": "https://eucpilots.com/evergreen-docs/troubleshoot/"
+        "Docs": "https://eucpilots.com/evergreen/",
+        "Issues": "https://eucpilots.com/evergreen/issues/",
+        "Info": "https://eucpilots.com/evergreen/troubleshoot/"
     }
 }

--- a/Evergreen/Evergreen.psd1
+++ b/Evergreen/Evergreen.psd1
@@ -112,13 +112,13 @@ PrivateData = @{
         LicenseUri = 'https://github.com/EUCPilots/evergreen-module/blob/main/LICENSE'
 
         # A URL to the main website for this project.
-        ProjectUri = 'https://eucpilots.com/evergreen-docs/'
+        ProjectUri = 'https://eucpilots.com/evergreen/'
 
         # A URL to an icon representing this module.
         IconUri = 'https://raw.githubusercontent.com/eucpilots/evergreen-module/refs/heads/main/img/evergreenbulb.png'
 
         # ReleaseNotes of this module
-        ReleaseNotes = 'https://eucpilots.com/evergreen-docs/changelog'
+        ReleaseNotes = 'https://eucpilots.com/evergreen/changelog'
 
         # Prerelease string of this module
         # Prerelease = ''

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -9,7 +9,7 @@ function Get-Architecture {
     switch -Regex ($String.ToLower()) {
         "aarch64" { $architecture = "ARM64"; break }
         "amd64" { $architecture = "x64"; break }
-        "anycpu" { $architecture = "AnyCPU"; break }
+        "anycpu" { $architecture = "any"; break }
         "arm64" { $architecture = "ARM64"; break }
         "arm32" { $architecture = "ARM32"; break }
         "arm" { $architecture = "ARM"; break }

--- a/Evergreen/Private/Get-Architecture.ps1
+++ b/Evergreen/Private/Get-Architecture.ps1
@@ -7,33 +7,34 @@ function Get-Architecture {
     )
 
     switch -Regex ($String.ToLower()) {
-        "aarch64"   { $architecture = "ARM64"; break }
-        "amd64"     { $architecture = "x64"; break }
-        "arm64"     { $architecture = "ARM64"; break }
-        "arm32"     { $architecture = "ARM32"; break }
-        "arm"       { $architecture = "ARM64"; break }
-        "nt64"      { $architecture = "x64"; break }
-        "nt32"      { $architecture = "x86"; break }
-        "win64"     { $architecture = "x64"; break }
-        "win32"     { $architecture = "x86"; break }
+        "aarch64" { $architecture = "ARM64"; break }
+        "amd64" { $architecture = "x64"; break }
+        "anycpu" { $architecture = "AnyCPU"; break }
+        "arm64" { $architecture = "ARM64"; break }
+        "arm32" { $architecture = "ARM32"; break }
+        "arm" { $architecture = "ARM"; break }
+        "nt64" { $architecture = "x64"; break }
+        "nt32" { $architecture = "x86"; break }
+        "win64" { $architecture = "x64"; break }
+        "win32" { $architecture = "x86"; break }
         "win-arm64" { $architecture = "ARM64"; break }
-        "win-x64"   { $architecture = "x64"; break }
-        "win-x86"   { $architecture = "x86"; break }
-        "x86_64"    { $architecture = "x64"; break }
-        "x64"       { $architecture = "x64"; break }
-        "w64"       { $architecture = "x64"; break }
-        "-64"       { $architecture = "x64"; break }
-        "64-bit"    { $architecture = "x64"; break }
-        "64bit"     { $architecture = "x64"; break }
-        "32-bit"    { $architecture = "x86"; break }
-        "32bit"     { $architecture = "x86"; break }
-        "x32"       { $architecture = "x86"; break }
-        "w32"       { $architecture = "x86"; break }
-        "-32"       { $architecture = "x86"; break }
-        "-x86"      { $architecture = "x86"; break }
-        "x86"       { $architecture = "x86"; break }
-        "e64\."       { $architecture = "x64"; break }
-        "64\."       { $architecture = "x64"; break }
+        "win-x64" { $architecture = "x64"; break }
+        "win-x86" { $architecture = "x86"; break }
+        "x86_64" { $architecture = "x64"; break }
+        "x64" { $architecture = "x64"; break }
+        "w64" { $architecture = "x64"; break }
+        "-64" { $architecture = "x64"; break }
+        "64-bit" { $architecture = "x64"; break }
+        "64bit" { $architecture = "x64"; break }
+        "32-bit" { $architecture = "x86"; break }
+        "32bit" { $architecture = "x86"; break }
+        "x32" { $architecture = "x86"; break }
+        "w32" { $architecture = "x86"; break }
+        "-32" { $architecture = "x86"; break }
+        "-x86" { $architecture = "x86"; break }
+        "x86" { $architecture = "x86"; break }
+        "e64\." { $architecture = "x64"; break }
+        "64\." { $architecture = "x64"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Architecture not found in $String, defaulting to x86."
             $architecture = "x86"

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -7,16 +7,18 @@ function Get-InstallerType {
     )
 
     switch -Regex ($String.ToLower()) {
-        "min" { $Type = "Minimal"; break }
-        "user" { $Type = "User"; break }
-        "portable" { $Type = "Portable"; break }
-        "no-installer" { $Type = "Portable"; break }
-        "debug" { $Type = "Debug"; break }
         "airgap" { $Type = "Airgap"; break }
-        "winmsi" { $Type = "MSI"; break }
+        "debug" { $Type = "Debug"; break }
+        "grouppolicy" { $Type = "GroupPolicy"; break }
+        "minimalist" { $Type = "Minimal"; break }
         "ndm" { $Type = "NonDarkMode"; break }
-        "qt6" { $Type = "Qt6"; break }
+        "no-installer" { $Type = "Portable"; break }
+        "noadmin" { $Type = "NoAdmin"; break }
+        "portable" { $Type = "Portable"; break }
         "qt5" { $Type = "Qt5"; break }
+        "qt6" { $Type = "Qt6"; break }
+        "user" { $Type = "User"; break }
+        "winmsi" { $Type = "MSI"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
             $Type = "Default"

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -7,13 +7,16 @@ function Get-InstallerType {
     )
 
     switch -Regex ($String.ToLower()) {
-        "min"          { $Type = "Minimal"; break }
-        "user"         { $Type = "User"; break }
-        "portable"     { $Type = "Portable"; break }
+        "min" { $Type = "Minimal"; break }
+        "user" { $Type = "User"; break }
+        "portable" { $Type = "Portable"; break }
         "no-installer" { $Type = "Portable"; break }
-        "debug"        { $Type = "Debug"; break }
-        "airgap"       { $Type = "Airgap"; break }
-        "winmsi"       { $Type = "MSI"; break }
+        "debug" { $Type = "Debug"; break }
+        "airgap" { $Type = "Airgap"; break }
+        "winmsi" { $Type = "MSI"; break }
+        "ndm" { $Type = "NonDarkMode"; break }
+        "qt6" { $Type = "Qt6"; break }
+        "qt5" { $Type = "Qt5"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
             $Type = "Default"

--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -13,6 +13,7 @@ function Get-InstallerType {
         "no-installer" { $Type = "Portable"; break }
         "debug"        { $Type = "Debug"; break }
         "airgap"       { $Type = "Airgap"; break }
+        "winmsi"       { $Type = "MSI"; break }
         default {
             Write-Verbose -Message "$($MyInvocation.MyCommand): Installer type not found in $String, defaulting to 'Default'."
             $Type = "Default"

--- a/Evergreen/Shared/Get-GitHubRepoRelease.ps1
+++ b/Evergreen/Shared/Get-GitHubRepoRelease.ps1
@@ -195,7 +195,7 @@ function Get-GitHubRepoRelease {
                             # Build the output object
                             if ((Get-Platform -String $asset.browser_download_url) -eq "Windows") {
 
-                                $PSObject = [PSCustomObject] @{
+                                $Object = [PSCustomObject] @{
                                     Version       = $Version
                                     Date          = ConvertTo-DateTime -DateTime $item.created_at -Pattern "MM/dd/yyyy HH:mm:ss"
                                     Size          = $asset.size
@@ -205,7 +205,13 @@ function Get-GitHubRepoRelease {
                                     Type          = [System.IO.Path]::GetExtension($asset.browser_download_url).Split(".")[-1]
                                     URI           = $asset.browser_download_url
                                 }
-                                Write-Output -InputObject $PSObject
+
+                                # If the asset doesn't have a digest property, remove the Sha256 property from the output object
+                                if ($null -eq $asset.digest) {
+                                    $Object.PSObject.Properties.Remove('Sha256')
+                                }
+
+                                Write-Output -InputObject $Object
                             }
                         }
                         else {

--- a/Evergreen/en-US/Evergreen-help.xml
+++ b/Evergreen/en-US/Evergreen-help.xml
@@ -48,7 +48,7 @@
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -81,7 +81,7 @@
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Export application version information</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/convertversion/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/convertversion/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -211,7 +211,7 @@
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -229,11 +229,11 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Export-EvergreenApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Export-EvergreenApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Export application version information</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/export/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/export/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -302,7 +302,7 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -318,11 +318,11 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Export-EvergreenManifest/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Export-EvergreenManifest/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Getting started with Evergreen</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -391,7 +391,7 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -421,11 +421,11 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Find-EvergreenApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Find-EvergreenApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Find supported applications</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/find/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/find/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -643,7 +643,7 @@ Export-EvergreenApp -InputObject $OneDrive -Path "C:\Evergreen\OneDrive\Microsof
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -718,11 +718,11 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Use Evergreen</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/use/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/use/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -791,7 +791,7 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -823,11 +823,11 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenAppFromApi/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenAppFromApi/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
-        <maml:linkText>https://eucpilots.com/evergreen-docs/invoke/</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/invoke/</maml:uri>
+        <maml:linkText>https://eucpilots.com/evergreen/invoke/</maml:linkText>
+        <maml:uri>https://eucpilots.com/evergreen/invoke/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -920,7 +920,7 @@ URI          : https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservi
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -974,11 +974,11 @@ Architecture : x64</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenLibraryApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenLibraryApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Create an Evergreen library:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/getlibrary.html</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/getlibrary.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1013,7 +1013,7 @@ Architecture : x64</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -1029,7 +1029,7 @@ Architecture : x64</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenAppsPath/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenAppsPath/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1099,7 +1099,7 @@ Architecture : x64</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -1148,11 +1148,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenEndpointFromApi/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenEndpointFromApi/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Retrieve endpoints used by Evergreen</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/endpoints/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/endpoints/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1248,7 +1248,7 @@ c.1password.com</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -1271,11 +1271,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenLibrary/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Get-EvergreenLibrary/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Create an Evergreen library</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/getlibrary.html</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/getlibrary.html</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1405,7 +1405,7 @@ c.1password.com</dev:code>
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs Author: Aaron Parker</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
     <command:examples>
@@ -1427,11 +1427,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/New-EvergreenLibrary/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/New-EvergreenLibrary/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Create an Evergreen library:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/newlibrary/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/newlibrary/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -1828,7 +1828,7 @@ c.1password.com</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -1851,11 +1851,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Save-EvergreenApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Save-EvergreenApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Download application installers:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/save</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/save</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -2014,7 +2014,7 @@ c.1password.com</dev:code>
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -2030,11 +2030,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Start-EvergreenLibraryUpdate/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Start-EvergreenLibraryUpdate/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Update an Evergreen library</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/updatelibrary/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/updatelibrary/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -2279,7 +2279,7 @@ c.1password.com</dev:code>
     </command:returnValues>
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -2295,11 +2295,11 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Save-EvergreenApp/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Save-EvergreenApp/</maml:uri>
       </maml:navigationLink>
       <maml:navigationLink>
         <maml:linkText>Test installers</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/test/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/test/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>
@@ -2373,7 +2373,7 @@ c.1password.com</dev:code>
     <command:returnValues />
     <maml:alertSet>
       <maml:alert>
-        <maml:para>Site: https://eucpilots.com/evergreen-docs</maml:para>
+        <maml:para>Site: https://eucpilots.com/evergreen</maml:para>
         <maml:para>Author: Aaron Parker</maml:para>
       </maml:alert>
     </maml:alertSet>
@@ -2403,7 +2403,7 @@ c.1password.com</dev:code>
     <command:relatedLinks>
       <maml:navigationLink>
         <maml:linkText>Online Version:</maml:linkText>
-        <maml:uri>https://eucpilots.com/evergreen-docs/help/en-US/Update-Evergreen/</maml:uri>
+        <maml:uri>https://eucpilots.com/evergreen/help/en-US/Update-Evergreen/</maml:uri>
       </maml:navigationLink>
     </command:relatedLinks>
   </command:command>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Evergreen is a simple PowerShell module to return the latest version and downloa
 * [Image creation with Hashicorp Packer](https://github.com/aaronparker/packer) - images can be created with the latest version of a set of applications
 * Import applications into Configuration Manager or [Microsoft Intune](https://github.com/aaronparker/packagefactory) and keep applications up to date with the latest versions
 * Validating or auditing a desktop image to ensure the current version of an application is installed
-* Create a [library of application installers](https://eucpilots.com/evergreen-docs/newlibrary/) - by regularly running Evergreen functions, you can retrieve and download the current version of an application and store it in an application directory structure for later use
+* Create a [library of application installers](https://eucpilots.com/evergreen/newlibrary/) - by regularly running Evergreen functions, you can retrieve and download the current version of an application and store it in an application directory structure for later use
 * [Track application updates](https://stealthpuppy.com/apptracker) to stay on top of new releases
 * Submitting manifests to `Winget` or `Chocolatey` or similar - Evergreen can return an object with a version number and download URL that can be used to construct manifests for the most recent versions
 
@@ -51,11 +51,11 @@ Evergreen's focus is on integration for PowerShell scripts to provide product ve
 
 ## Documentation
 
-Documentation for Evergreen, including usage examples, is located here: [https://eucpilots.com/evergreen-docs/](https://eucpilots.com/evergreen-docs/).
+Documentation for Evergreen, including usage examples, is located here: [https://eucpilots.com/evergreen/](https://eucpilots.com/evergreen/).
 
 ## Versioning
 
-The module uses a version notation that follows: YearMonth.Build. It is expected that the module will have changes on a regular basis, so the version numbering is intended to make it as simple as possible to understand when the last update was made. See the [CHANGELOG](https://eucpilots.com/evergreen-docs/changelog/) for details on changes introduced in each version.
+The module uses a version notation that follows: YearMonth.Build. It is expected that the module will have changes on a regular basis, so the version numbering is intended to make it as simple as possible to understand when the last update was made. See the [CHANGELOG](https://eucpilots.com/evergreen/changelog/) for details on changes introduced in each version.
 
 ## Installing the Module
 

--- a/help/README.md
+++ b/help/README.md
@@ -5,7 +5,7 @@ platyPS help markdown can be found here: [/docs/help](/docs/help).
 To generate the external help use `New-ExternalHelp`:
 
 ```powershell
-Update-MarkdownHelp -Path "/Users/aaron/projects/_EUCPilots/evergreen-docs/docs/help/en-US"
+Update-MarkdownHelp -Path "/Users/aaron/projects/_EUCPilots/evergreen/docs/help/en-US"
 New-ExternalHelp -Path "help/en-US" -OutputPath "Evergreen/en-US" -Encoding ([System.Text.Encoding]::UTF8) -Force
 ```
 

--- a/help/en-US/ConvertTo-DotNetVersionClass.md
+++ b/help/en-US/ConvertTo-DotNetVersionClass.md
@@ -74,10 +74,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Export application version information](https://eucpilots.com/evergreen-docs/convertversion/)
+[Export application version information](https://eucpilots.com/evergreen/convertversion/)

--- a/help/en-US/Export-EvergreenApp.md
+++ b/help/en-US/Export-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Export-EvergreenApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Export-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -114,10 +114,10 @@ Export-EvergreenApp accepts the output from Get-EvergreenApp.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Export application version information](https://eucpilots.com/evergreen-docs/export/)
+[Export application version information](https://eucpilots.com/evergreen/export/)

--- a/help/en-US/Export-EvergreenManifest.md
+++ b/help/en-US/Export-EvergreenManifest.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Export-EvergreenManifest/
+online version: https://eucpilots.com/evergreen/help/en-US/Export-EvergreenManifest/
 schema: 2.0.0
 ---
 
@@ -64,10 +64,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Getting started with Evergreen](https://eucpilots.com/evergreen-docs/)
+[Getting started with Evergreen](https://eucpilots.com/evergreen/)

--- a/help/en-US/Find-EvergreenApp.md
+++ b/help/en-US/Find-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Find-EvergreenApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Find-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -83,10 +83,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Find supported applications](https://eucpilots.com/evergreen-docs/find/)
+[Find supported applications](https://eucpilots.com/evergreen/find/)

--- a/help/en-US/Get-EvergreenApp.md
+++ b/help/en-US/Get-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -246,10 +246,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Use Evergreen](https://eucpilots.com/evergreen-docs/use/)
+[Use Evergreen](https://eucpilots.com/evergreen/use/)

--- a/help/en-US/Get-EvergreenAppFromApi.md
+++ b/help/en-US/Get-EvergreenAppFromApi.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenAppFromApi/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenAppFromApi/
 schema: 2.0.0
 ---
 
@@ -83,10 +83,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[https://eucpilots.com/evergreen-docs/invoke/](https://eucpilots.com/evergreen-docs/invoke/)
+[https://eucpilots.com/evergreen/invoke/](https://eucpilots.com/evergreen/invoke/)

--- a/help/en-US/Get-EvergreenAppFromLibrary.md
+++ b/help/en-US/Get-EvergreenAppFromLibrary.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenLibraryApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenLibraryApp/
 schema: 2.0.0
 ---
 
@@ -119,10 +119,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Create an Evergreen library:](https://eucpilots.com/evergreen-docs/getlibrary.html)
+[Create an Evergreen library:](https://eucpilots.com/evergreen/getlibrary.html)

--- a/help/en-US/Get-EvergreenAppsPath.md
+++ b/help/en-US/Get-EvergreenAppsPath.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenAppsPath/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenAppsPath/
 schema: 2.0.0
 ---
 
@@ -38,6 +38,6 @@ Returns the local cache path for the Evergreen apps functions and manifests.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker

--- a/help/en-US/Get-EvergreenEndpointFromApi.md
+++ b/help/en-US/Get-EvergreenEndpointFromApi.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenEndpointFromApi/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenEndpointFromApi/
 schema: 2.0.0
 ---
 
@@ -104,10 +104,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Retrieve endpoints used by Evergreen](https://eucpilots.com/evergreen-docs/endpoints/)
+[Retrieve endpoints used by Evergreen](https://eucpilots.com/evergreen/endpoints/)

--- a/help/en-US/Get-EvergreenLibrary.md
+++ b/help/en-US/Get-EvergreenLibrary.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Get-EvergreenLibrary/
+online version: https://eucpilots.com/evergreen/help/en-US/Get-EvergreenLibrary/
 schema: 2.0.0
 ---
 
@@ -94,10 +94,10 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Create an Evergreen library](https://eucpilots.com/evergreen-docs/getlibrary.html)
+[Create an Evergreen library](https://eucpilots.com/evergreen/getlibrary.html)

--- a/help/en-US/New-EvergreenLibrary.md
+++ b/help/en-US/New-EvergreenLibrary.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/New-EvergreenLibrary/
+online version: https://eucpilots.com/evergreen/help/en-US/New-EvergreenLibrary/
 schema: 2.0.0
 ---
 
@@ -121,8 +121,8 @@ New-EvergreenLibrary accepts string parameters.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 Author: Aaron Parker
 ## RELATED LINKS
 
-[Create an Evergreen library:](https://eucpilots.com/evergreen-docs/newlibrary/)
+[Create an Evergreen library:](https://eucpilots.com/evergreen/newlibrary/)

--- a/help/en-US/Save-EvergreenApp.md
+++ b/help/en-US/Save-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Save-EvergreenApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Save-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -252,10 +252,10 @@ Provides a list of paths of the downloaded target files.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Download application installers:](https://eucpilots.com/evergreen-docs/save)
+[Download application installers:](https://eucpilots.com/evergreen/save)

--- a/help/en-US/Start-EvergreenLibraryUpdate.md
+++ b/help/en-US/Start-EvergreenLibraryUpdate.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Start-EvergreenLibraryUpdate/
+online version: https://eucpilots.com/evergreen/help/en-US/Start-EvergreenLibraryUpdate/
 schema: 2.0.0
 ---
 
@@ -135,10 +135,10 @@ Start-EvergreenLibraryUpdate accepts a string parameter.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Update an Evergreen library](https://eucpilots.com/evergreen-docs/updatelibrary/)
+[Update an Evergreen library](https://eucpilots.com/evergreen/updatelibrary/)

--- a/help/en-US/Test-EvergreenApp.md
+++ b/help/en-US/Test-EvergreenApp.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Save-EvergreenApp/
+online version: https://eucpilots.com/evergreen/help/en-US/Save-EvergreenApp/
 schema: 2.0.0
 ---
 
@@ -192,10 +192,10 @@ Provides a list URLs and a true/false result.
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 
 ## RELATED LINKS
 
-[Test installers](https://eucpilots.com/evergreen-docs/test/)
+[Test installers](https://eucpilots.com/evergreen/test/)

--- a/help/en-US/Update-Evergreen.md
+++ b/help/en-US/Update-Evergreen.md
@@ -1,7 +1,7 @@
 ---
 external help file: Evergreen-help.xml
 Module Name: Evergreen
-online version: https://eucpilots.com/evergreen-docs/help/en-US/Update-Evergreen/
+online version: https://eucpilots.com/evergreen/help/en-US/Update-Evergreen/
 schema: 2.0.0
 ---
 
@@ -90,7 +90,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 
 ## NOTES
 
-Site: https://eucpilots.com/evergreen-docs
+Site: https://eucpilots.com/evergreen
 
 Author: Aaron Parker
 


### PR DESCRIPTION
* `Get-GitHubRepoRelease` - Add logic to remove the Sha256 property when the asset has no digest. This prevents emitting an empty Sha256 field for Windows assets and ensures the output object only contains the digest when present
* `Get-InstallerType ` - Add more output strings to provide more values to `InstallerType` property. Address [#124](https://github.com/EUCPilots/evergreen-apps/issues/124)
* Normalise "anycpu" to "any", and "aarch64" to "ARM64" in `Get-Architecture`