### PR TITLE
Fetch SHA256 checksum and handle failures

### DIFF
--- a/Evergreen/Shared/Get-JetBrainsApp.ps1
+++ b/Evergreen/Shared/Get-JetBrainsApp.ps1
@@ -23,12 +23,22 @@ function Get-JetBrainsApp {
             Write-Warning -Message "$($MyInvocation.MyCommand): 'downloads.windows.link' property is null; from '$uri'."
         }
         else {
+
+            try {
+                $Sha256 = Invoke-EvergreenRestMethod -Uri $UpdateFeed.$($Edition.Value).downloads.windows.checksumLink
+                $Sha256 = ($Sha256 -split '\s+')[0]
+            }
+            catch {
+                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to retrieve the SHA256 checksum from '$($UpdateFeed.$($Edition.Value).downloads.windows.checksumLink)'. Error: $_"
+                $Sha256 = $null
+            }
+
             # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
                 Version = $UpdateFeed.$($Edition.Value).version
                 Build   = $UpdateFeed.$($Edition.Value).build
                 Edition = $Edition.Key
-                Sha256  = $UpdateFeed.$($Edition.Value).downloads.windows.checksumLink
+                Sha256  = $Sha256
                 Date    = ConvertTo-DateTime -DateTime $UpdateFeed.$($Edition.Value).date -Pattern $res.Get.Update.DatePattern
                 Size    = $UpdateFeed.$($Edition.Value).downloads.windows.size
                 Type    = Get-FileType -File $UpdateFeed.$($Edition.Value).downloads.windows.link


### PR DESCRIPTION
Replace returning the checksum link with an actual SHA256 value by invoking Invoke-EvergreenRestMethod on the downloads.windows.checksumLink, splitting the response to extract the checksum, and assigning it to Sha256. Add try/catch to emit a warning and set Sha256 to $null on failure, preserving existing metadata (Version, Build, Edition, Date, Size, Type). Improves robustness when checksum retrieval fails.