### PR TITLE
Updates

### DIFF
--- a/Evergreen/Private/Get-InstallerType.ps1
+++ b/Evergreen/Private/Get-InstallerType.ps1
@@ -10,6 +10,7 @@ function Get-InstallerType {
         "airgap" { $Type = "Airgap"; break }
         "debug" { $Type = "Debug"; break }
         "grouppolicy" { $Type = "GroupPolicy"; break }
+        "legacy" { $Type = "Legacy"; break }
         "minimalist" { $Type = "Minimal"; break }
         "ndm" { $Type = "NonDarkMode"; break }
         "no-installer" { $Type = "Portable"; break }

--- a/Evergreen/Shared/Get-JetBrainsApp.ps1
+++ b/Evergreen/Shared/Get-JetBrainsApp.ps1
@@ -30,7 +30,7 @@ function Get-JetBrainsApp {
             }
             catch {
                 Write-Warning -Message "$($MyInvocation.MyCommand): Failed to retrieve the SHA256 checksum from '$($UpdateFeed.$($Edition.Value).downloads.windows.checksumLink)'. Error: $_"
-                $Sha256 = $null
+                $Sha256 = $UpdateFeed.$($Edition.Value).downloads.windows.checksumLink
             }
 
             # Construct the output; Return the custom object to the pipeline

--- a/Evergreen/Shared/Get-JetBrainsApp.ps1
+++ b/Evergreen/Shared/Get-JetBrainsApp.ps1
@@ -23,12 +23,22 @@ function Get-JetBrainsApp {
             Write-Warning -Message "$($MyInvocation.MyCommand): 'downloads.windows.link' property is null; from '$uri'."
         }
         else {
+
+            try {
+                $Sha256 = Invoke-EvergreenRestMethod -Uri $UpdateFeed.$($Edition.Value).downloads.windows.checksumLink
+                $Sha256 = ($Sha256 -split '\s+')[0]
+            }
+            catch {
+                Write-Warning -Message "$($MyInvocation.MyCommand): Failed to retrieve the SHA256 checksum from '$($UpdateFeed.$($Edition.Value).downloads.windows.checksumLink)'. Error: $_"
+                $Sha256 = $null
+            }
+
             # Construct the output; Return the custom object to the pipeline
             $PSObject = [PSCustomObject] @{
                 Version = $UpdateFeed.$($Edition.Value).version
                 Build   = $UpdateFeed.$($Edition.Value).build
                 Edition = $Edition.Key
-                Sha256  = $UpdateFeed.$($Edition.Value).downloads.windows.checksumLink
+                Sha256  = $Sha256
                 Date    = ConvertTo-DateTime -DateTime $UpdateFeed.$($Edition.Value).date -Pattern $res.Get.Update.DatePattern
                 Size    = $UpdateFeed.$($Edition.Value).downloads.windows.size
                 Type    = Get-FileType -File $UpdateFeed.$($Edition.Value).downloads.windows.link


### PR DESCRIPTION
* Replace returning the checksum link with an actual `SHA256` value by invoking `Invoke-EvergreenRestMethod` on the `downloads.windows.checksumLink`, splitting the response to extract the checksum, and assigning it to `Sha256`. Add **try/catch** to emit a warning and set `Sha256` to the checksum file URL on failure, preserving existing metadata (Version, Build, Edition, Date, Size, Type). Improves robustness when checksum retrieval fails
* Recognize the 'legacy' installer option in `Get-InstallerType.ps1` by mapping it to the "Legacy" type. This ensures callers passing 'legacy' are correctly identified. (`Evergreen/Private/Get-InstallerType.ps1`). Address #905 