### PR TITLE
Null output from expand.exe in Expand-CabArchive

### DIFF
--- a/Evergreen/Private/Expand-CabArchive.ps1
+++ b/Evergreen/Private/Expand-CabArchive.ps1
@@ -31,7 +31,7 @@ function Expand-CabArchive {
             $DestinationPath = Join-Path -Path $DestinationPath -ChildPath (New-Guid)
             New-Item -Path $DestinationPath -ItemType "Directory" -Force | Out-Null
             if (Test-Path -Path $ExpandExe) {
-                & $ExpandExe $Path -I $DestinationPath
+                & $ExpandExe $Path -I $DestinationPath | Out-Null
                 $Items = Get-ChildItem -Path $DestinationPath -File -Recurse | Select-Object -ExpandProperty "FullName"
                 if ($null -ne $Items) {
                     return $Items


### PR DESCRIPTION
Prevents error from being thrown in Get-Content, as detailed in issue https://github.com/EUCPilots/evergreen-module/issues/898